### PR TITLE
Closes #5

### DIFF
--- a/install_github.R
+++ b/install_github.R
@@ -29,7 +29,7 @@ install_github = function(repo,
     if(method == "auto") {
         
         if(unix) {
-            if(capabilities("libcurl")) {
+            if(file.exists(Sys.which("libcurl"))) {
                 method = "libcurl"
             } else if (file.exists(Sys.which("wget"))) {
                 method = "wget"

--- a/install_github.R
+++ b/install_github.R
@@ -18,6 +18,18 @@
 #'   \code{auto}, this function will make an educated guess.
 #' @examples
 #' \dontrun{install_github("jtilly/matchingR")}
+if (getRversion() < '3.2.0') {
+  trimws = function (x, which = c("both", "left", "right")) {
+    which <- match.arg(which)
+    mysub <- function(re, x) sub(re, "", x, perl = TRUE)
+    if (which == "left") 
+        return(mysub("^[ \\t\\r\\n]+", x))
+    if (which == "right") 
+        return(mysub("[ \\t\\r\\n]+$", x))
+    mysub("[ \\t\\r\\n]+$", mysub("^[ \\t\\r\\n]+", x))
+  }
+}
+
 install_github = function(repo, 
                           branch = if (grepl("@", repo)) gsub(".*@", "", repo) else "master", 
                           dependencies = TRUE, method = "auto") {


### PR DESCRIPTION
since `capabilities` functionality is version-dependent, use `file.exists(Sys.which(.))` approach for `libcurl` as well